### PR TITLE
Clear screen

### DIFF
--- a/public/scripts/game/souvenir/Silhouette.js
+++ b/public/scripts/game/souvenir/Silhouette.js
@@ -25,6 +25,11 @@ export default class Silhouette {
         config.addColor('inhale_color', inhale_color);
     }
 
+    /** Clears the internal graphics buffer */
+    clear() {
+        this.g.clear();
+    }
+
     /** Every render, the cumulative image is dimmed then a silhouette of the user is drawn on top. */
     render() {
 

--- a/public/scripts/game/souvenir/SmokeTrails.js
+++ b/public/scripts/game/souvenir/SmokeTrails.js
@@ -84,6 +84,11 @@ export default class Smoke {
     
     }
 
+    /** Clears the internal graphics buffer */
+    clear() {
+        this._g.clear();
+    }
+
     /** Blend smoke trails into an offscreen buffer then draw it into the main context*/
     render() {
         // this._g.background(0,0,0,5);

--- a/public/scripts/game/states/GameState.js
+++ b/public/scripts/game/states/GameState.js
@@ -56,6 +56,14 @@ export default class GameState extends State {
 			this.p5.saveCanvas("screenshot.jpg");
 		});
 
+		this.clearscreen = this.p5.createElement('button', 'Clear Screen');
+		this.clearscreen.parent( this.section );
+		this.clearscreen.mousePressed( ()=>{
+			this.silhouette.clear();
+			this.smoke.clear();
+			this.p5.clear();
+		})
+
 		//Make sure skeleton is already loaded, load if not
 		if(!this.gameSession.skeletonLoaded){
 			this.gameSession.skeleton = new Skeleton();

--- a/public/styles/game.css
+++ b/public/styles/game.css
@@ -6,8 +6,9 @@ section.game {
     width: 100%;
 
     display: flex;
-    flex-direction: column-reverse;
-    align-items: center;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items:end;
 
     /* General styling */
     color: var(--primary-color);
@@ -18,12 +19,8 @@ section.game {
 }
 
 section.game img {
-    align-self: center;
-    justify-self: center;
     border: var(--primary-color) 4px solid;
     padding: 5px;
-    background: black;
-    margin: var(--text-size);
 }
 
 section.game img:first-of-type {
@@ -37,6 +34,3 @@ section.game img:last-of-type {
     right: 5%;
     top: 5%;
 }
-
-/* section.game button {
-} */


### PR DESCRIPTION
Added a button to the game state that clears the souvenirs' graphics buffers and the p5 canvas.
Changed game state's styling to just list things like buttons at the bottom of the screen.